### PR TITLE
ADD "Use Potentionmeter for Offset Angle Calibration" Column

### DIFF
--- a/res/config/6.05/parameters_mcconf.xml
+++ b/res/config/6.05/parameters_mcconf.xml
@@ -3177,7 +3177,7 @@ p, li { white-space: pre-wrap; }
             <suffix> °</suffix>
             <vTx>9</vTx>
         </p_pid_offset>
-        <p_pid_pot_offset_calib>
+        <p_pid_offset_pot_calib>
             <longName>Use Potentionmeter for Offset Angle Calibration</longName>
             <type>5</type>
             <transmittable>1</transmittable>
@@ -3186,9 +3186,9 @@ p, li { white-space: pre-wrap; }
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Allow the speed controller to to apply braking current. In general this option should be enabled, but for some applications it might make sense to disable braking during speed control.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
-            <cDefine>MCCONF_P_PID_POT_OFFSET_CALIB</cDefine>
+            <cDefine>MCCONF_P_PID_OFFSET_POT_CALIB</cDefine>
             <valInt>0</valInt>
-        </p_pid_pot_offset_calib>
+        </p_pid_offset_pot_calib>
         <p_pid_kd_proc>
             <longName>Position PID Kd Process</longName>
             <type>1</type>
@@ -4673,7 +4673,7 @@ p, li { white-space: pre-wrap; }
         <ser>p_pid_ang_div</ser>
         <ser>p_pid_gain_dec_angle</ser>
         <ser>p_pid_offset</ser>
-        <ser>p_pid_pot_offset_calib</ser>
+        <ser>p_pid_offset_pot_calib</ser>
         <ser>cc_startup_boost_duty</ser>
         <ser>cc_min_current</ser>
         <ser>cc_gain</ser>
@@ -5072,7 +5072,7 @@ p, li { white-space: pre-wrap; }
                     <param>p_pid_ang_div</param>
                     <param>p_pid_gain_dec_angle</param>
                     <param>p_pid_offset</param>
-                    <param>p_pid_pot_offset_calib</param>
+                    <param>p_pid_offset_pot_calib</param>
                 </subgroupParams>
             </subgroup>
         </group>

--- a/res/config/6.05/parameters_mcconf.xml
+++ b/res/config/6.05/parameters_mcconf.xml
@@ -3177,6 +3177,18 @@ p, li { white-space: pre-wrap; }
             <suffix> °</suffix>
             <vTx>9</vTx>
         </p_pid_offset>
+        <p_pid_pot_offset_calib>
+            <longName>Use Potentionmeter for Offset Angle Calibration</longName>
+            <type>5</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Allow the speed controller to to apply braking current. In general this option should be enabled, but for some applications it might make sense to disable braking during speed control.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>MCCONF_P_PID_POT_OFFSET_CALIB</cDefine>
+            <valInt>0</valInt>
+        </p_pid_pot_offset_calib>
         <p_pid_kd_proc>
             <longName>Position PID Kd Process</longName>
             <type>1</type>
@@ -4661,6 +4673,7 @@ p, li { white-space: pre-wrap; }
         <ser>p_pid_ang_div</ser>
         <ser>p_pid_gain_dec_angle</ser>
         <ser>p_pid_offset</ser>
+        <ser>p_pid_pot_offset_calib</ser>
         <ser>cc_startup_boost_duty</ser>
         <ser>cc_min_current</ser>
         <ser>cc_gain</ser>
@@ -5059,6 +5072,7 @@ p, li { white-space: pre-wrap; }
                     <param>p_pid_ang_div</param>
                     <param>p_pid_gain_dec_angle</param>
                     <param>p_pid_offset</param>
+                    <param>p_pid_pot_offset_calib</param>
                 </subgroupParams>
             </subgroup>
         </group>

--- a/vescinterface.cpp
+++ b/vescinterface.cpp
@@ -3402,7 +3402,7 @@ void VescInterface::packetDataToSend(QByteArray &data)
 
                 mCanDevice->writeFrame(frame);
                 mCanDevice->waitForFramesWritten(5);
-//                QThread::msleep(5);
+                QThread::msleep(1);
                 payload.clear();
             }
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
- ポテンショメータでオフセットを調整するかどうかを選択するための項目を追加.
- ついでに大きなフレームの書き込みがエラーで落ちる問題を修正.

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->


<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
- [x] ビルドが通った
- [x] 実機で動確した

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
